### PR TITLE
Add Codex setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ We are using the fantastic uv platform and setup should be relatively painless!
 - Windows people, your instructions are [here](setup/SETUP-PC.md)
 - Mac people, yours are [here](setup/SETUP-mac.md)
 - Linux people, yours are [here](setup/SETUP-linux.md)
+- Codex users can run [`setup/setup_codex.sh`](setup/setup_codex.sh) to install
+  dependencies and the CrewAI CLI automatically.
 
 ### Then for CrewAI Setup:
 

--- a/setup/setup_codex.sh
+++ b/setup/setup_codex.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv not found. Installing..."
+    curl -Ls https://astral.sh/uv/install.sh | bash
+fi
+
+uv sync
+uv tool install crewai
+uv tool upgrade crewai
+
+echo "Remember to create the .env file with your API keys as described in setup/SETUP-linux.md"


### PR DESCRIPTION
## Summary
- add `setup/setup_codex.sh` to automate setting up the repo
- document the new script in README

## Testing
- `bash -n setup/setup_codex.sh`


------
https://chatgpt.com/codex/tasks/task_b_68801979f46c832ebe471b4d1b75cd8a