### PR TITLE
Implement persistent SQLite memory server

### DIFF
--- a/3_trading_floor/mcp_params.py
+++ b/3_trading_floor/mcp_params.py
@@ -29,5 +29,5 @@ def researcher_mcp_server_params(name: str):
     return [
         {"command": "uvx", "args": ["mcp-server-fetch"]},
         {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-brave-search"], "env": brave_env},
-        {"command": "uv", "args": ["run", "memory_server_inmemory.py"], "env": {"MEMORY_NAME": name}}
+        {"command": "uv", "args": ["run", "memory_server_sqlite.py"], "env": {"MEMORY_NAME": name}}
     ]

--- a/3_trading_floor/memory_server_sqlite.py
+++ b/3_trading_floor/memory_server_sqlite.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import json
+import sqlite3
+
+MEMORY_NAME = os.environ.get("MEMORY_NAME", "default")
+DB_DIR = os.path.join(os.path.dirname(__file__), "memory")
+os.makedirs(DB_DIR, exist_ok=True)
+DB_PATH = os.path.join(DB_DIR, f"{MEMORY_NAME}.db")
+
+conn = sqlite3.connect(DB_PATH)
+cursor = conn.cursor()
+cursor.execute("CREATE TABLE IF NOT EXISTS memory (key TEXT PRIMARY KEY, value TEXT)")
+conn.commit()
+
+print(f"[memory_server_sqlite] Starting SQLite memory server: {DB_PATH}")
+
+try:
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        try:
+            cmd = json.loads(line)
+            action = cmd.get("action")
+            key = cmd.get("key")
+            value = cmd.get("value")
+            if action == "set":
+                cursor.execute("REPLACE INTO memory(key, value) VALUES (?, ?)", (key, json.dumps(value)))
+                conn.commit()
+                print(json.dumps({"status": "ok"}))
+            elif action == "get":
+                cursor.execute("SELECT value FROM memory WHERE key = ?", (key,))
+                row = cursor.fetchone()
+                print(json.dumps({"value": json.loads(row[0]) if row else None}))
+            elif action == "clear":
+                cursor.execute("DELETE FROM memory")
+                conn.commit()
+                print(json.dumps({"status": "cleared"}))
+            else:
+                print(json.dumps({"error": "unknown action"}))
+        except Exception as e:
+            print(json.dumps({"error": str(e)}))
+        sys.stdout.flush()
+except KeyboardInterrupt:
+    pass
+finally:
+    conn.close()
+    print("[memory_server_sqlite] Shutting down.")


### PR DESCRIPTION
## Summary
- add a new SQLite-based memory server for storing key/value data
- start this durable server for researchers instead of the in-memory version

## Testing
- `python -m py_compile 3_trading_floor/memory_server_sqlite.py 3_trading_floor/mcp_params.py`

------
https://chatgpt.com/codex/tasks/task_b_6883c07da790832e983c506d856ae3f5