### PR TITLE
Add centralized error logging

### DIFF
--- a/3_trading_floor/logger.py
+++ b/3_trading_floor/logger.py
@@ -1,0 +1,12 @@
+from database import write_log
+
+
+def log_error(name: str, message: str) -> None:
+    """Log an error message for the given agent."""
+    write_log(name.lower(), "error", message)
+
+
+def log_exception(name: str, exc: Exception, context: str | None = None) -> None:
+    """Log an exception with optional context."""
+    msg = f"{context}: {exc}" if context else str(exc)
+    log_error(name, msg)

--- a/3_trading_floor/market.py
+++ b/3_trading_floor/market.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import random
 from database import write_market, read_market
 from functools import lru_cache
+from logger import log_exception
 
 load_dotenv(override=True)
 
@@ -57,5 +58,6 @@ def get_share_price(symbol) -> float:
         try:
             return get_share_price_polygon(symbol)
         except Exception as e:
+            log_exception("market", e, "Polygon API error")
             print(f"Was not able to use the polygon API due to {e}; using a random number")
     return float(random.randint(1, 100))

--- a/3_trading_floor/memory_server_inmemory.py
+++ b/3_trading_floor/memory_server_inmemory.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+from logger import log_exception
 
 # Minimal in-memory key-value store for demonstration
 memory = {}
@@ -31,6 +32,7 @@ try:
             else:
                 print(json.dumps({"error": "unknown action"}))
         except Exception as e:
+            log_exception(MEMORY_NAME, e, "memory server error")
             print(json.dumps({"error": str(e)}))
         sys.stdout.flush()
 except KeyboardInterrupt:

--- a/3_trading_floor/traders.py
+++ b/3_trading_floor/traders.py
@@ -9,6 +9,7 @@ import json
 from agents.mcp import MCPServerStdio
 from templates import researcher_instructions, trader_instructions, trade_message, rebalance_message, research_tool
 from mcp_params import trader_mcp_server_params, researcher_mcp_server_params
+from logger import log_exception
 load_dotenv(override=True)
 
 deepseek_api_key = os.getenv("DEEPSEEK_API_KEY")
@@ -106,6 +107,7 @@ class Trader:
         try:
             await self.run_with_trace()
         except Exception as e:
+            log_exception(self.name, e, "Error running trader")
             print(f"Error running trader {self.name}: {e}")
         self.do_trade = not self.do_trade
 


### PR DESCRIPTION
## Summary
- introduce `logger` module for error logging
- log exceptions in `Trader`, `market`, and `memory_server_inmemory`
- wire new logger with existing components

## Testing
- `pytest 2_engineering_team/output/test_accounts.py -q`
- `pytest 2_engineering_team/engineering_team/example_output_4o/test_accounts.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6883c0a63820832e8ed365e504e563aa