### PR TITLE
Add basic tests for trading floor modules

### DIFF
--- a/tests/test_accounts_operations.py
+++ b/tests/test_accounts_operations.py
@@ -1,0 +1,59 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+# Make trading floor modules importable
+sys.path.insert(0, os.path.abspath('3_trading_floor'))
+
+import accounts
+
+
+class AccountOperationsTest(unittest.TestCase):
+    def setUp(self):
+        # In-memory store instead of sqlite
+        self.store = {}
+
+        def fake_write(name, data):
+            self.store[name.lower()] = data
+
+        def fake_read(name):
+            return self.store.get(name.lower())
+
+        patches = [
+            patch('accounts.write_account', side_effect=fake_write),
+            patch('accounts.read_account', side_effect=fake_read),
+            patch('accounts.write_log'),
+            patch('accounts.get_share_price', return_value=100.0),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+        self.account = accounts.Account.get('Alice')
+
+    def test_buy_and_sell_shares(self):
+        # Buy 10 shares at $100 each plus spread
+        self.account.buy_shares('AAPL', 10, 'init')
+        expected_balance_after_buy = accounts.INITIAL_BALANCE - 10 * 100 * (1 + accounts.SPREAD)
+        self.assertAlmostEqual(self.account.balance, expected_balance_after_buy)
+        self.assertEqual(self.account.holdings, {'AAPL': 10})
+
+        # Sell 5 of them
+        self.account.sell_shares('AAPL', 5, 'take profit')
+        expected_balance_after_sell = expected_balance_after_buy + 5 * 100 * (1 - accounts.SPREAD)
+        self.assertAlmostEqual(self.account.balance, expected_balance_after_sell)
+        self.assertEqual(self.account.holdings, {'AAPL': 5})
+        self.assertEqual(len(self.account.transactions), 2)
+
+    def test_profit_loss_calculation(self):
+        self.account.buy_shares('AAPL', 10, 'init')
+        self.account.sell_shares('AAPL', 5, 'take profit')
+        value = self.account.calculate_portfolio_value()
+        pnl = self.account.calculate_profit_loss(value)
+        # Expected small negative due to spread costs
+        self.assertAlmostEqual(pnl, -3.0, places=1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_market_integration.py
+++ b/tests/test_market_integration.py
@@ -1,0 +1,24 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath('3_trading_floor'))
+import market
+
+class MarketIntegrationTest(unittest.TestCase):
+    def test_get_share_price_no_key(self):
+        with patch.object(market, 'polygon_api_key', None), \
+             patch('random.randint', return_value=42):
+            price = market.get_share_price('AAPL')
+            self.assertEqual(price, 42.0)
+
+    def test_get_share_price_api_error(self):
+        with patch.object(market, 'polygon_api_key', 'key'), \
+             patch.object(market, 'get_share_price_polygon', side_effect=RuntimeError('fail')), \
+             patch('random.randint', return_value=77):
+            price = market.get_share_price('AAPL')
+            self.assertEqual(price, 77.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for account buy/sell logic and P/L calculation
- cover market price fallback logic with integration tests

## Testing
- `python -m unittest discover tests -v`

------
https://chatgpt.com/codex/tasks/task_b_6883c0c001a0832eac7ed62f948323c0