### PR TITLE
Add risk and audit logging

### DIFF
--- a/3_trading_floor/accounts.py
+++ b/3_trading_floor/accounts.py
@@ -1,14 +1,17 @@
 from pydantic import BaseModel
 import json
+import os
 from dotenv import load_dotenv
 from datetime import datetime
 from market import get_share_price
 from database import write_account, read_account, write_log
+from logger import log_risk, log_audit
 
 load_dotenv(override=True)
 
 INITIAL_BALANCE = 10_000.0
 SPREAD = 0.002
+MAX_SINGLE_TRADE_FRACTION = float(os.getenv("MAX_SINGLE_TRADE_FRACTION", "0.3"))
 
 
 class Transaction(BaseModel):
@@ -81,10 +84,17 @@ class Account(BaseModel):
         price = get_share_price(symbol)
         buy_price = price * (1 + SPREAD)
         total_cost = buy_price * quantity
-        
+
+        portfolio_value = self.calculate_portfolio_value()
+        if total_cost > portfolio_value * MAX_SINGLE_TRADE_FRACTION:
+            log_risk(self.name, f"Buy {quantity} {symbol} rejected: trade value ${total_cost:.2f} exceeds limit")
+            raise ValueError("Trade size exceeds risk limit.")
+
         if total_cost > self.balance:
+            log_risk(self.name, f"Buy {quantity} {symbol} rejected: insufficient funds")
             raise ValueError("Insufficient funds to buy shares.")
-        elif price==0:
+        elif price == 0:
+            log_risk(self.name, f"Buy {quantity} {symbol} rejected: unrecognized symbol")
             raise ValueError(f"Unrecognized symbol {symbol}")
         
         # Update holdings
@@ -98,16 +108,23 @@ class Account(BaseModel):
         self.balance -= total_cost
         self.save()
         write_log(self.name, "account", f"Bought {quantity} of {symbol}")
+        log_audit(self.name, f"Bought {quantity} {symbol} at {buy_price}")
         return "Completed. Latest details:\n" + self.report()
 
     def sell_shares(self, symbol: str, quantity: int, rationale: str) -> str:
         """ Sell shares of a stock if the user has enough shares. """
         if self.holdings.get(symbol, 0) < quantity:
+            log_risk(self.name, f"Sell {quantity} {symbol} rejected: insufficient shares")
             raise ValueError(f"Cannot sell {quantity} shares of {symbol}. Not enough shares held.")
         
         price = get_share_price(symbol)
         sell_price = price * (1 - SPREAD)
         total_proceeds = sell_price * quantity
+
+        portfolio_value = self.calculate_portfolio_value()
+        if total_proceeds > portfolio_value * MAX_SINGLE_TRADE_FRACTION:
+            log_risk(self.name, f"Sell {quantity} {symbol} rejected: trade value ${total_proceeds:.2f} exceeds limit")
+            raise ValueError("Trade size exceeds risk limit.")
         
         # Update holdings
         self.holdings[symbol] -= quantity
@@ -124,6 +141,7 @@ class Account(BaseModel):
         self.balance += total_proceeds
         self.save()
         write_log(self.name, "account", f"Sold {quantity} of {symbol}")
+        log_audit(self.name, f"Sold {quantity} {symbol} at {sell_price}")
         return "Completed. Latest details:\n" + self.report()
 
     def calculate_portfolio_value(self):

--- a/3_trading_floor/logger.py
+++ b/3_trading_floor/logger.py
@@ -10,3 +10,13 @@ def log_exception(name: str, exc: Exception, context: str | None = None) -> None
     """Log an exception with optional context."""
     msg = f"{context}: {exc}" if context else str(exc)
     log_error(name, msg)
+
+
+def log_risk(name: str, message: str) -> None:
+    """Log a risk-related incident for the given agent."""
+    write_log(name.lower(), "risk", message)
+
+
+def log_audit(name: str, message: str) -> None:
+    """Log an audit trail message for the given agent."""
+    write_log(name.lower(), "audit", message)

--- a/3_trading_floor/market.py
+++ b/3_trading_floor/market.py
@@ -1,6 +1,7 @@
 from polygon import RESTClient
 from dotenv import load_dotenv
 import os
+import random
 from datetime import datetime
 from typing import Dict
 from database import write_market, read_market
@@ -79,5 +80,12 @@ def get_share_price(symbol) -> float:
             return price
         except Exception as e:
             print(f"Was not able to use the polygon API due to {e}; using cached value")
-    return _get_cached_price(symbol)
             log_exception("market", e, "Polygon API error")
+            cached = _get_cached_price(symbol)
+            if cached:
+                return cached
+            return float(random.randint(1, 100))
+    cached = _get_cached_price(symbol)
+    if cached:
+        return cached
+    return float(random.randint(1, 100))


### PR DESCRIPTION
## Summary
- log risk and audit events
- respect trade size limits in `Account`
- simulate share prices when polygon API fails or unavailable
- clean up market logging

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_b_688a5df62194832eaab811e528eed399